### PR TITLE
Actualizacion de dockerfile del frontend, dockercompose y readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,8 @@ cd project-base
 ### 2. Inicializar los contenedores del Backend (Ktor) + DB (Postgres) + Frontend (Next.js)
 
 ```bash
-docker compose up -d
+docker compose up --build (-d -> Para que corra en segundo plano)  
 ```
-
-### 2.1. Si ya se corrieron los contenedores al menos una vez, se recomienda utilizar este en su lugar.
-
-```bash
-docker compose up --no-recreate --build -d
-```
-
 ### 3. Acceder a la página [principal](http://localhost:3000/)
 
 ## Finalizar los contenedores

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,14 +40,11 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "3000:3000"
     networks:
       - app_network
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
-      - /app/.next
 
 networks:
   app_network:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1
-
-FROM node:lts-alpine AS base
+FROM node:18-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -9,13 +7,20 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi
+
+FROM base AS dev
+
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
 
 
 # Rebuild the source code only when needed
@@ -27,22 +32,19 @@ COPY . .
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+RUN yarn build
+
+# If using npm comment out above and use below instead
+# RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -56,11 +58,5 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
-EXPOSE 3000
 
-ENV PORT=3000
-
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
 CMD ["node", "server.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,66 @@
-FROM node:lts-alpine
+# syntax=docker.io/docker/dockerfile:1
 
+FROM node:lts-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-COPY package.json yarn.lock ./
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
 
-RUN yarn install
 
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN yarn build
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
 
 EXPOSE 3000
 
-CMD ["yarn", "start"]
+ENV PORT=3000
 
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,10 +34,19 @@ yarn install
 
 Esto descargará todas las dependencias necesarias definidas en `package.json`.
 
-## 4. Ejecutar el servidor de desarrollo
+## 5. Ejecutar el servidor de desarrollo
 
 Para iniciar el servidor de desarrollo local, usa:
 
 ```bash
 yarn dev
 ```
+
+## 6. Ejecutar el servidor de desarrollo
+
+Inicializar el Backend y la base de datos
+
+```bash
+docker compose up api db (-d -> para que se ejecute en segundo plano)
+```
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,55 +1,43 @@
-# Next.js & HeroUI Template
+# Instrucciones para trabajar con el frontend en modo de desarrollo (Se refresca automáticamente al modificar cualquier archivo)
 
-This is a template for creating applications using Next.js 14 (pages directory) and HeroUI (v2).
+## 1. Instalar NVM (Node Version Manager)
 
-[Try it on CodeSandbox](https://githubbox.com/heroui-inc/next-pages-template)
-
-> Note: Since Next.js 14, the pages router is recommend migrating to the [new App Router](https://nextjs.org/docs/app) to leverage React's latest features
->
-> Read more: [Pages Router](https://nextjs.org/docs/pages)
-
-## Technologies Used
-
-- [Next.js 14](https://nextjs.org/docs/getting-started)
-- [HeroUI](https://heroui.com)
-- [Tailwind CSS](https://tailwindcss.com)
-- [Tailwind Variants](https://tailwind-variants.org)
-- [TypeScript](https://www.typescriptlang.org)
-- [Framer Motion](https://www.framer.com/motion)
-- [next-themes](https://github.com/pacocoursey/next-themes)
-
-## How to Use
-
-To create a new project based on this template using `create-next-app`, run the following command:
+Instala NVM ejecutando:
 
 ```bash
-npx create-next-app -e https://github.com/heroui-inc/next-pages-template
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 ```
+> **Nota:** Es posible que necesites cerrar y volver a abrir tu terminal
 
-### Install dependencies
+## 2. Instalar la última versión LTS de Node.js
 
-You can use one of them `npm`, `yarn`, `pnpm`, `bun`, Example using `npm`:
+Con NVM instalado, ejecuta:
 
 ```bash
-npm install
+nvm install --lts
 ```
 
-### Run the development server
+## 3. Instalar el manejador de dependencias YARN
+
 
 ```bash
-npm run dev
+npm install -g yarn
 ```
 
-### Setup pnpm (optional)
+## 4. Instalar dependencias del frontend
 
-If you are using `pnpm`, you need to add the following code to your `.npmrc` file:
+Navega a la carpeta de frontend y ejecuta:
 
 ```bash
-public-hoist-pattern[]=*@heroui/*
+yarn install
 ```
 
-After modifying the `.npmrc` file, you need to run `pnpm install` again to ensure that the dependencies are installed correctly.
+Esto descargará todas las dependencias necesarias definidas en `package.json`.
 
-## License
+## 4. Ejecutar el servidor de desarrollo
 
-Licensed under the [MIT license](https://github.com/heroui-inc/next-pages-template/blob/main/LICENSE).
+Para iniciar el servidor de desarrollo local, usa:
+
+```bash
+yarn dev
+```

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
   output: "standalone",
 }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  output: "standalone",
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Se actualiza el dockerfile del frontend para que no tenga que descargar los paquetes cada vez que se ejecuta docker compose, seguirá siendo necesario agregar --build para refrescar los cambios, en teoria con esto ya no tenemos problemas con el caché, después de varias pruebas con solo correr docker compose up --build se hacen visibles los cambios

para más detalles revisar los readmes.